### PR TITLE
Fix generated color-token verification on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,5 +8,7 @@
 *.yaml text eol=lf
 *.sh text eol=lf
 *.txt text eol=lf
+*.css text eol=lf
+*.svg text eol=lf
 *.bat text eol=crlf
 *.cmd text eol=crlf


### PR DESCRIPTION
## Summary
- force LF line endings for generated CSS and SVG assets
- prevent Windows GitHub Actions checkouts from converting generated color artifacts to CRLF
- keep byte-for-byte staleness verification deterministic across Linux, macOS, and Windows

## Root cause
The color-token verifier compares generated output byte-for-byte. `.gitattributes` enforced LF for JavaScript and YAML, but not for the generated `.css` and `.svg` files. On Windows runners, checkout could convert all four tracked generated artifacts to CRLF, causing `npm run verify:color-tokens` to report them as stale even though the repository blobs were current.