### PR TITLE
Fix CI packaged output resolution and Electron acceptance setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
       - run: npm ci --ignore-scripts
       - run: npm ci
         working-directory: electron
+      - name: Install Electron test binary
+        run: node electron/node_modules/electron/install.js
+      - name: Verify Electron test binary
+        run: test -x electron/node_modules/electron/dist/electron
       - run: npm run verify:color-tokens
       - run: npm run audit:production
       - run: npm run test:native-tasks-release-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
             package-lock.json
             electron/package-lock.json
       - run: npm ci --ignore-scripts
-      - run: npm ci --ignore-scripts
+      - run: npm ci
         working-directory: electron
       - run: npm run verify:color-tokens
       - run: npm run audit:production
       - run: npm run test:native-tasks-release-gate
-      - run: npm run test:all
+      - run: xvfb-run --auto-servernum npm run test:all
 
   packaged-app:
     runs-on: windows-latest
@@ -59,9 +59,14 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $packageDirectory = (node scripts/current-unpacked.mjs).Trim()
-          if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $packageDirectory -PathType Container)) {
-            throw 'Could not resolve the promoted unpacked application.'
+          $packageDirectory = node scripts/current-unpacked.mjs --allow-build-check
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Could not resolve the unpacked application produced by electron:build.'
+          }
+          $packageDirectory = [string]$packageDirectory
+          $packageDirectory = $packageDirectory.Trim()
+          if (-not $packageDirectory -or -not (Test-Path -LiteralPath $packageDirectory -PathType Container)) {
+            throw 'Resolved unpacked application path is missing or invalid.'
           }
           "path=$packageDirectory" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
       - name: Verify packaged application layout

--- a/scripts/current-unpacked.mjs
+++ b/scripts/current-unpacked.mjs
@@ -61,7 +61,9 @@ function assertPackageDirectory(directory, markerPath) {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  console.log(resolveCurrentUnpacked());
+  console.log(resolveCurrentUnpacked(defaultRoot, {
+    allowBuildCheck: process.argv.includes('--allow-build-check')
+  }));
 }
 
 export { resolveCurrentUnpacked, resolveCurrentUnpackedFromDist };


### PR DESCRIPTION
## Summary
- allow `current-unpacked.mjs` to resolve `dist/build-check/win-unpacked` from the CLI
- update the Windows packaged-app workflow to request build-check output explicitly and report command failures cleanly
- install the Electron binary in the Linux CI job and run the browser acceptance suite under Xvfb

## Root causes
1. `npm run electron:build` intentionally writes to `dist/build-check/win-unpacked`, while the workflow called `current-unpacked.mjs` in release-only mode.
2. The Linux job installed Electron with lifecycle scripts disabled, then ran `dashboard-browser-acceptance.mjs`, which requires the downloaded Electron binary.